### PR TITLE
Update app.py

### DIFF
--- a/nessus_file_analyzer/app.py
+++ b/nessus_file_analyzer/app.py
@@ -2952,7 +2952,7 @@ class ParsingThread(QThread):
         :param additional_info: add more information if needed
         """
         notification = f'[action={action_name}] [source_file_name={source_file_name}] {additional_info}'
-        self.signal.emit(notification)
+        self.signal.emit(str(notification))
 
 
 def main():


### PR DESCRIPTION
Error messages:
[2023-07-12 20:04:00.462644] [action=info] [source_file_name=ERROR Parsing [1/1] nessus files]  [2023-07-12 20:04:00.463644] [action=info] [source_file_name=unsupported operand type(s) for +=: 'NoneType' and 'int']

By adding str(notification), you ensure that the notification is converted to a string before being emitted. This should resolve the error caused by concatenating a NoneType and an int.